### PR TITLE
roll back version to 4.5.0

### DIFF
--- a/web3j.rb
+++ b/web3j.rb
@@ -2,7 +2,7 @@
 class Web3j < Formula
   desc "web3j command line tools for Ethereum"
   homepage "https://github.com/web3j/web3j"
-  url "https://github.com/web3j/web3j/releases/download/v4.5.1/web3j-4.5.1.zip"
+  url "https://github.com/web3j/web3j/releases/download/v4.5.1/web3j-4.5.0.zip"
   # update with: shasum -a 256
   sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
 

--- a/web3j.rb
+++ b/web3j.rb
@@ -2,7 +2,7 @@
 class Web3j < Formula
   desc "web3j command line tools for Ethereum"
   homepage "https://github.com/web3j/web3j"
-  url "https://github.com/web3j/web3j/releases/download/v4.5.1/web3j-4.5.0.zip"
+  url "https://github.com/web3j/web3j/releases/download/v4.5.0/web3j-4.5.0.zip"
   # update with: shasum -a 256
   sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
 


### PR DESCRIPTION
To fix [issue](https://github.com/web3j/web3j/issues/1037) caused by the latest pipeline implementations. 